### PR TITLE
check active close from peer in ngx_http_check_recv_handler()

### DIFF
--- a/ngx_http_upstream_check_handler.c
+++ b/ngx_http_upstream_check_handler.c
@@ -544,10 +544,10 @@ ngx_http_check_send_handler(ngx_event_t *event)
                        size, ctx->send.last - ctx->send.pos);
 #endif
 
-        if (size >= 0) {
+        if (size > 0) {
             ctx->send.pos += size;
 
-        } else if (size == NGX_AGAIN) {
+        } else if (size == 0 || size == NGX_AGAIN) {
             return;
 
         } else {


### PR DESCRIPTION
If there is no data to receive, we finish the health check before timeout.
 Note that, without this patch, timeout handler will do it for us.
