### PR TITLE
JSON status to simplify automatic monitoring

### DIFF
--- a/ngx_http_upstream_check_handler.c
+++ b/ngx_http_upstream_check_handler.c
@@ -1654,8 +1654,8 @@ ngx_http_upstream_check_status_handler(ngx_http_request_t *r)
         return rc;
     }
 
-    r->headers_out.content_type.len = sizeof("text/html; charset=utf-8") - 1;
-    r->headers_out.content_type.data = (u_char *) "text/html; charset=utf-8";
+    r->headers_out.content_type.len = sizeof("application/json; charset=utf-8") - 1;
+    r->headers_out.content_type.data = (u_char *) "application/json; charset=utf-8";
 
     if (r->method == NGX_HTTP_HEAD) {
         r->headers_out.status = NGX_HTTP_OK;
@@ -1693,53 +1693,30 @@ ngx_http_upstream_check_status_handler(ngx_http_request_t *r)
     out.next = NULL;
 
     b->last = ngx_snprintf(b->last, b->end - b->last,
-            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\n"
-            "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
-            "<head>\n"
-            "  <title>Nginx http upstream check status</title>\n"
-            "</head>\n"
-            "<body>\n"
-            "<h1>Nginx http upstream check status</h1>\n"
-            "<h2>Check upstream server number: %ui, generation: %ui</h2>\n"
-            "<table style=\"background-color:white\" cellspacing=\"0\" "
-            "       cellpadding=\"3\" border=\"1\">\n"
-            "  <tr bgcolor=\"#C0C0C0\">\n"
-            "    <th>Index</th>\n"
-            "    <th>Upstream</th>\n"
-            "    <th>Name</th>\n"
-            "    <th>Status</th>\n"
-            "    <th>Rise counts</th>\n"
-            "    <th>Fall counts</th>\n"
-            "    <th>Check type</th>\n"
-            "  </tr>\n",
+            "{ \"upstream_servers\": %ui, \"generation\": %ui, \"peers\": [ ",
             peers->peers.nelts, ngx_http_check_shm_generation);
 
     for (i = 0; i < peers->peers.nelts; i++) {
         b->last = ngx_snprintf(b->last, b->end - b->last,
-                "  <tr%s>\n"
-                "    <td>%ui</td>\n"
-                "    <td>%V</td>\n"
-                "    <td>%V</td>\n"
-                "    <td>%s</td>\n"
-                "    <td>%ui</td>\n"
-                "    <td>%ui</td>\n"
-                "    <td>%s</td>\n"
-                "  </tr>\n",
-                peer_shm[i].down ? " bgcolor=\"#FF0000\"" : "",
-                i,
+                "{ \"upstream\": \"%V\", "
+                "\"member\": \"%V\", "
+                "\"status\": \"%s\", "
+                "\"rise_count\": %ui, "
+                "\"fall_count\": %ui, "
+                "\"check_type\": \"%s\""
+                "} %s",
                 peer[i].upstream_name,
                 &peer[i].peer_addr->name,
                 peer_shm[i].down ? "down" : "up",
                 peer_shm[i].rise_count,
                 peer_shm[i].fall_count,
-                peer[i].conf->check_type_conf->name);
+                peer[i].conf->check_type_conf->name,
+                (i < (peers->peers.nelts - 1)) ? ", " : ""
+                );
     }
 
     b->last = ngx_snprintf(b->last, b->end - b->last,
-            "</table>\n"
-            "</body>\n"
-            "</html>\n");
+            "] }");
 
     r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_length_n = b->last - b->pos;


### PR DESCRIPTION
Hi,

we modified the the status resource to return json instead of a HTML table. This can be used to simplify monitoring. Example output looks like this:

```
{
  upstream_servers: 4,
  generation: 1,
  peers: [
    {
      upstream: "example-api.com",
      member: "192.168.1.1:80",
      status: "up",
      rise_count: 8,
      fall_count: 0,
      check_type: "http"
    },
    {
      upstream: "www.example-app.com",
      member: "192.168.1.2:80",
      status: "up",
      rise_count: 8,
      fall_count: 0,
      check_type: "http"
    },
    {
      upstream: "www.company.com",
      member: "192.168.1.3:80",
      status: "up",
      rise_count: 9,
      fall_count: 0,
      check_type: "http"
    },
  ]
}
```

There is lot's of room for improvement regarding the structure of the hash but i still hope you like the idea.

Cheers!
Daniel
