### PR TITLE
Retain correct fall and rise count for same IP address in different upstreams while reloading

### DIFF
--- a/ngx_http_upstream_check_handler.h
+++ b/ngx_http_upstream_check_handler.h
@@ -72,6 +72,7 @@ typedef struct {
     ngx_atomic_t down;
 
     ngx_uint_t   access_count;
+    ngx_str_t    *upstream_name;
 
     struct sockaddr  *sockaddr;
     socklen_t         socklen;


### PR DESCRIPTION
While reloading, the rise and fall count of same IP address is same irrespective of upstream group.

For example,

upstream check
{
server 127.0.0.1:80;
server 127.0.0.1:8080;
check interval=5000 rise=2 fall=2 timeout=3000 default_down=true type=http;
check_http_send "GET / HTTP/1.0\r\n\r\n";
check_http_expect_alive http_2xx;
}

upstream check-ro
{
server 127.0.0.1:80;
server 127.0.0.1:8081;
check interval=5000 rise=2 fall=2 timeout=3000 default_down=true type=http;
check_http_send "GET / HTTP/1.0\r\n\r\n";
check_http_expect_alive http_3xx;
}

while reloading, the rise and fall count of 127.0.0.1:80 in check-ro upstream is same as that of 127.0.0.1:80 in check upstream which gives the false result.

The proposed fix is to store upstream name with peer details in shared memory.

The downside is that I have to introduce an extra field "upstream_name" in ngx_http_check_peer_t in my patch, which increases the shared memory size.

Comments are welcome.
