### PR TITLE
Return 204 for status if health check is not configured

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -2709,11 +2709,11 @@ ngx_http_upstream_check_status_handler(ngx_http_request_t *r)
 
     peers = check_peers_ctx;
     if (peers == NULL) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "http upstream check module can not find any check "
                       "server, make sure you've added the check servers");
 
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        return NGX_HTTP_NO_CONTENT;
     }
 
     /* 1/4 pagesize for each record */


### PR DESCRIPTION
If configuration is empty it is not an error per se, so instead of
returning 500 we can simply return 204.
