### PR TITLE
upstream check: do not require connection to be NULL

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -1042,8 +1042,7 @@ ngx_http_upstream_check_begin_handler(ngx_event_t *event)
     ngx_add_timer(event, ucscf->check_interval / 2);
 
     /* This process is processing this peer now. */
-    if ((peer->shm->owner == ngx_pid  ||
-        (peer->pc.connection != NULL) ||
+    if ((peer->shm->owner == ngx_pid ||
         peer->check_timeout_ev.timer_set)) {
         return;
     }


### PR DESCRIPTION
ngx_http_upstream_check_connect_handler already accounts for non-NULL
connection
