### PR TITLE
Fixed the issue where checker is not working properly when check_keep…

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -1043,7 +1043,6 @@ ngx_http_upstream_check_begin_handler(ngx_event_t *event)
 
     /* This process is processing this peer now. */
     if ((peer->shm->owner == ngx_pid  ||
-        (peer->pc.connection != NULL) ||
         peer->check_timeout_ev.timer_set)) {
         return;
     }


### PR DESCRIPTION
…alive_requests is set to greater than 1.

The checker will only send the first check request and then wait until the upstream timesout the keepalive link.
Fix is based on tengine code from https://github.com/alibaba/tengine