### PR TITLE
Update ssl_check for services mandating newer versions of TLS

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -595,27 +595,32 @@ static ngx_str_t fastcgi_default_params[] = {
  */
 static char sslv3_client_hello_pkt[] = {
     "\x16"                /* ContentType         : 0x16 = Hanshake           */
-    "\x03\x00"            /* ProtocolVersion     : 0x0300 = SSLv3            */
-    "\x00\x79"            /* ContentLength       : 0x79 bytes after this one */
+    "\x03\x01"            /* ProtocolVersion     : 0x0301 = TLSv1.0          */
+    "\x00\x6f"            /* ContentLength       : 0x6f bytes after this one */
     "\x01"                /* HanshakeType        : 0x01 = CLIENT HELLO       */
-    "\x00\x00\x75"        /* HandshakeLength     : 0x75 bytes after this one */
-    "\x03\x00"            /* Hello Version       : 0x0300 = v3               */
+    "\x00\x00\x6b"        /* HandshakeLength     : 0x6b bytes after this one */
+    "\x03\x03"            /* Hello Version       : 0x0303 = TLSv1.2          */
     "\x00\x00\x00\x00"    /* Unix GMT Time (s)   : filled with <now> (@0x0B) */
     NGX_SSL_RANDOM        /* Random              : must be exactly 28 bytes  */
     "\x00"                /* Session ID length   : empty (no session ID)     */
-    "\x00\x4E"            /* Cipher Suite Length : 78 bytes after this one   */
-    "\x00\x01" "\x00\x02" "\x00\x03" "\x00\x04" /* 39 most common ciphers :  */
-    "\x00\x05" "\x00\x06" "\x00\x07" "\x00\x08" /* 0x01...0x1B, 0x2F...0x3A  */
-    "\x00\x09" "\x00\x0A" "\x00\x0B" "\x00\x0C" /* This covers RSA/DH,       */
-    "\x00\x0D" "\x00\x0E" "\x00\x0F" "\x00\x10" /* various bit lengths,      */
-    "\x00\x11" "\x00\x12" "\x00\x13" "\x00\x14" /* SHA1/MD5, DES/3DES/AES... */
-    "\x00\x15" "\x00\x16" "\x00\x17" "\x00\x18"
-    "\x00\x19" "\x00\x1A" "\x00\x1B" "\x00\x2F"
-    "\x00\x30" "\x00\x31" "\x00\x32" "\x00\x33"
-    "\x00\x34" "\x00\x35" "\x00\x36" "\x00\x37"
-    "\x00\x38" "\x00\x39" "\x00\x3A"
+    "\x00\x1a"            /* Cipher Suite Length : \x1a bytes after this one */
+    "\xc0\x2b" "\xc0\x2f" "\xcc\xa9" "\xcc\xa8"  /* 13 modern ciphers        */
+    "\xc0\x0a" "\xc0\x09" "\xc0\x13" "\xc0\x14"
+    "\x00\x33" "\x00\x39" "\x00\x2f" "\x00\x35"
+    "\x00\x0a"
     "\x01"                /* Compression Length  : 0x01 = 1 byte for types   */
     "\x00"                /* Compression Type    : 0x00 = NULL compression   */
+    "\x00\x28"            /* Extensions length */
+    "\x00\x0a"            /* EC extension */
+    "\x00\x08"            /* extension length */
+    "\x00\x06"            /* curves length */
+    "\x00\x17" "\x00\x18" "\x00\x19" /* Three curves */
+    "\x00\x0d"            /* Signature extension */
+    "\x00\x18"            /* extension length */
+    "\x00\x16"            /* hash list length */
+    "\x04\x01" "\x05\x01" "\x06\x01" "\x02\x01"  /* 11 hash algorithms */
+    "\x04\x03" "\x05\x03" "\x06\x03" "\x02\x03"
+    "\x05\x02" "\x04\x02" "\x02\x02"
 };
 
 


### PR DESCRIPTION
I needed to use the ssl_hello check at a client that uses TLSv1.2 only and has some 2012R2 IIS. This

required offering not just TLSv1.2 but also the right ciphers and extensions.

This patch updates the ssl_hello packet to:
1. Use TLS1 handshake
2. Advertise TLS 1.2 in Hello
3. Offer modern ciphers
4. Offer the elliptic curves extension
5. Offer a range of signature algorithms

This should be backwards compatible from my reading of the RFC, but I have not extensively verified this on any ancient and unsecured SSL services. :)
