### PR TITLE
bugfix: segfault while reloading

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -4060,5 +4060,12 @@ ngx_http_upstream_check_init_shm_peer(ngx_http_upstream_check_peer_shm_t *psh,
 static ngx_int_t
 ngx_http_upstream_check_init_process(ngx_cycle_t *cycle)
 {
+    ngx_http_upstream_check_main_conf_t *ucmcf;
+
+    ucmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_check_module);
+    if (ucmcf == NULL) {
+        return NGX_OK;
+    }
+
     return ngx_http_upstream_check_add_timers(cycle);
 }


### PR DESCRIPTION
reproduce:
1. use normal config with http{} and check directives in http{upstream{}}
2. start nginx
3. delete the whole http{} in config file
4. reload

	modified:   ngx_http_upstream_check_module.c