### PR TITLE
Fix config fail when there is Werror in CC flag

### DIFF
--- a/config
+++ b/config
@@ -1,11 +1,11 @@
 ngx_feature="ngx_http_upstream_check_module"
 ngx_feature_name=
 ngx_feature_run=no
-ngx_feature_incs=
+ngx_feature_incs="#include <stdio.h>"
 ngx_feature_path="$ngx_addon_dir"
 ngx_feature_deps="$ngx_addon_dir/ngx_http_upstream_check_module.h"
 ngx_check_src="$ngx_addon_dir/ngx_http_upstream_check_module.c"
-ngx_feature_test="int a;"
+ngx_feature_test='int a=0; printf("%d", a);'
 . auto/feature
 
 if [ $ngx_found = yes ]; then


### PR DESCRIPTION
There will be config fail when Werror is turned on in CC flag, the fail log is in autoconf.err

> checking for ngx_http_upstream_check_module
> objs/autotest.c: In function 'main':
> objs/autotest.c:7:9: error: unused variable 'a' [-Werror=unused-variable]
>    int a;;
>        ^
> cc1: all warnings being treated as errors

This should be avoided to save developer's time in investigating the config fail.