### PR TITLE
fix: only worker proccess can exec health check

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -4062,6 +4062,10 @@ ngx_http_upstream_check_init_process(ngx_cycle_t *cycle)
 {
     ngx_http_upstream_check_main_conf_t *ucmcf;
 
+    if (ngx_process != NGX_PROCESS_WORKER) {
+        return NGX_OK;
+    }
+
     ucmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_check_module);
     if (ucmcf == NULL) {
         return NGX_OK;


### PR DESCRIPTION
when upstream server increases and nginx add proxy_cache command, 512 worker_connections are not enough may occur in error log.
because helper process only have 512 connection.

relate issue:
https://github.com/yaoweibin/nginx_upstream_check_module/issues/145
https://github.com/weibocom/nginx-upsync-module/issues/172