### PR TITLE
bugfix: Filter status is down, check_status/API returns JSON error

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -2965,12 +2965,13 @@ static void
 ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
     ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
 {
-    ngx_uint_t                       count, i, last;
+    ngx_uint_t                       count, final, i, last;
     ngx_http_upstream_check_peer_t  *peer;
 
     peer = peers->peers.elts;
 
     count = 0;
+    final = 0;
 
     for (i = 0; i < peers->peers.nelts; i++) {
 
@@ -3013,7 +3014,9 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
                 continue;
             }
         }
-
+        
+        final++;
+        
         b->last = ngx_snprintf(b->last, b->end - b->last,
                 "    {\"index\": %ui, "
                 "\"upstream\": \"%V\", "
@@ -3032,7 +3035,7 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
                 peer[i].shm->fall_count,
                 &peer[i].conf->check_type_conf->name,
                 peer[i].conf->port,
-                (i == last) ? "" : ",");
+                (final == count) ? "" : ",");
     }
 
     b->last = ngx_snprintf(b->last, b->end - b->last,


### PR DESCRIPTION
$ curl -s "http://127.0.0.1/?format=json&status=down" 

returns JSON error
{
"servers": {
  "total": 2,
  "generation": 1,
  "server": [
    {"index": 35, "upstream": "www", "name": "127.0.0.1:8080", "status": "down", "rise": 0, "fall": 57, "type": "http", "port": 0},
    {"index": 123, "upstream": "task", "name": "127.0.0.1:8081", "status": "down", "rise": 0, "fall": 56, "type": "http", "port": 0},
  ]
}}