### PR TITLE
Add https support to check_http_send

### DIFF
--- a/README
+++ b/README
@@ -45,7 +45,7 @@ Directives
   check
     syntax: *check interval=milliseconds [fall=count] [rise=count]
     [timeout=milliseconds] [default_down=true|false]
-    [type=tcp|http|ssl_hello|mysql|ajp|fastcgi]*
+    [type=tcp|http|https|ssl_hello|mysql|ajp|fastcgi]*
 
     default: *none, if parameters omitted, default parameters are
     interval=30000 fall=5 rise=2 timeout=1000 default_down=true type=tcp*
@@ -83,13 +83,17 @@ Directives
         3.  *http* sends a http request packet, receives and parses the http
             response to diagnose if the upstream server is alive.
 
-        4.  *mysql* connects to the mysql server, receives the greeting
+        4.  *https* establishes a https connection and sends a http request
+            packet, receives and parses the http response to diagnose if the
+            upstream server is alive.
+
+        5.  *mysql* connects to the mysql server, receives the greeting
             response to diagnose if the upstream server is alive.
 
-        5.  *ajp* sends a AJP Cping packet, receives and parses the AJP
+        6.  *ajp* sends a AJP Cping packet, receives and parses the AJP
             Cpong response to diagnose if the upstream server is alive.
 
-        6.  *fastcgi* send a fastcgi request, receives and parses the
+        7.  *fastcgi* send a fastcgi request, receives and parses the
             fastcgi response to diagnose if the upstream server is alive.
 
   check_http_send

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -12,7 +12,6 @@ typedef struct ngx_http_upstream_check_peer_s ngx_http_upstream_check_peer_t;
 typedef struct ngx_http_upstream_check_srv_conf_s
     ngx_http_upstream_check_srv_conf_t;
 
-
 #pragma pack(push, 1)
 
 typedef struct {
@@ -239,6 +238,9 @@ struct ngx_http_upstream_check_srv_conf_s {
     ngx_array_t                             *fastcgi_params;
 
     ngx_uint_t                               default_down;
+#if (NGX_HTTP_SSL)
+    ngx_ssl_t                       ssl;
+#endif
 };
 
 
@@ -339,7 +341,10 @@ static ngx_int_t ngx_http_upstream_check_peek_one_byte(ngx_connection_t *c);
 
 static void ngx_http_upstream_check_begin_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_connect_handler(ngx_event_t *event);
-
+#if (NGX_HTTP_SSL)
+static void ngx_http_upstream_do_ssl_handshake(ngx_event_t *event);
+static void ngx_ups_ssl_handshake(ngx_connection_t *c);
+#endif
 static void ngx_http_upstream_check_peek_handler(ngx_event_t *event);
 
 static void ngx_http_upstream_check_send_handler(ngx_event_t *event);
@@ -666,7 +671,19 @@ static ngx_check_conf_t  ngx_check_types[] = {
       ngx_http_upstream_check_http_reinit,
       1,
       1 },
-
+#if (NGX_HTTP_SSL)
+    { NGX_HTTP_CHECK_HTTP,
+      ngx_string("https"),
+      ngx_string("GET / HTTP/1.0\r\n\r\n"),
+      NGX_CONF_BITMASK_SET | NGX_CHECK_HTTP_2XX | NGX_CHECK_HTTP_3XX,
+      ngx_http_upstream_check_send_handler,
+      ngx_http_upstream_check_recv_handler,
+      ngx_http_upstream_check_http_init,
+      ngx_http_upstream_check_http_parse,
+      ngx_http_upstream_check_http_reinit,
+      1,
+      1 },
+#endif
     { NGX_HTTP_CHECK_HTTP,
       ngx_string("fastcgi"),
       ngx_null_string,
@@ -975,7 +992,6 @@ ngx_http_upstream_check_add_timers(ngx_cycle_t *cycle)
 
     for (i = 0; i < peers->peers.nelts; i++) {
         peer[i].shm = &peer_shm[i];
-
         peer[i].check_ev.handler = ngx_http_upstream_check_begin_handler;
         peer[i].check_ev.log = cycle->log;
         peer[i].check_ev.data = &peer[i];
@@ -1108,6 +1124,7 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
 
     peer = event->data;
     ucscf = peer->conf;
+    int is_https_check_type = strcmp((const char *)peer->conf->check_type_conf->name.data, "https") == 0;
 
     if (peer->pc.connection != NULL) {
         c = peer->pc.connection;
@@ -1147,13 +1164,20 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
     c->read->log = c->log;
     c->write->log = c->log;
     c->pool = peer->pool;
+#if (NGX_HTTP_SSL)
+    if (is_https_check_type && rc == NGX_AGAIN) {
+        c->write->handler = ngx_http_upstream_do_ssl_handshake;
+        c->read->handler = ngx_http_upstream_do_ssl_handshake;
+    }
+#endif
 
 upstream_check_connect_done:
     peer->state = NGX_HTTP_CHECK_CONNECT_DONE;
 
-    c->write->handler = peer->send_handler;
-    c->read->handler = peer->recv_handler;
-
+    if (!is_https_check_type) {
+      c->write->handler = peer->send_handler;
+      c->read->handler = peer->recv_handler;
+    }
     ngx_add_timer(&peer->check_timeout_ev, ucscf->check_timeout);
 
     /* The kqueue's loop interface needs it. */
@@ -1161,6 +1185,69 @@ upstream_check_connect_done:
         c->write->handler(c->write);
     }
 }
+
+#if (NGX_HTTP_SSL)
+static void ngx_http_upstream_do_ssl_handshake(ngx_event_t *event) {
+    long                  rc;
+    ngx_connection_t                    *c;
+    ngx_http_upstream_check_peer_t      *peer;
+    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    c = event->data;
+    peer = c -> data;
+    ucscf = peer->conf;
+    ucscf->ssl.buffer_size = NGX_SSL_BUFSIZE;
+    ucscf->ssl.ctx = SSL_CTX_new(SSLv23_method());
+    rc = ngx_ssl_create_connection(&ucscf->ssl, c, NGX_SSL_BUFFER|NGX_SSL_CLIENT );
+    if (rc != NGX_OK){
+      return;
+    }
+    int tcp_nodelay = 1;
+    if (setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY,
+                   (const void *) &tcp_nodelay, sizeof(int)) == -1)
+    {
+        ngx_connection_error(c, ngx_socket_errno,
+                             "setsockopt(TCP_NODELAY) failed");
+        return;
+    }
+    c->tcp_nodelay = NGX_TCP_NODELAY_SET;
+    rc = ngx_ssl_handshake(c);
+    if (rc != NGX_OK && rc != NGX_AGAIN) {
+        ngx_ssl_shutdown(peer->pc.connection);
+        SSL_CTX_free(ucscf->ssl.ctx);
+        ucscf->ssl.ctx = NULL;
+        return;
+    }
+    if (rc == NGX_AGAIN) {
+        if (!c->write->timer_set) {
+            ngx_add_timer(c->write, ucscf->check_timeout);
+        }
+      c->ssl->handler = ngx_ups_ssl_handshake;
+    }
+    else {
+      ngx_ups_ssl_handshake(c);
+    }
+}
+
+static void
+ngx_ups_ssl_handshake(ngx_connection_t *c) {
+    long                  rc;
+    ngx_http_upstream_check_peer_t      *peer;
+    peer = c->data;
+    if (c->ssl && c->ssl->handshaked) {
+      rc = SSL_get_verify_result(c->ssl->connection);
+      if (rc != X509_V_OK) {
+          ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                        "upstream SSL certificate verify error: (%l:%s)",
+                        rc, X509_verify_cert_error_string(rc));
+      }
+    }
+    peer->state = NGX_HTTP_CHECK_CONNECT_DONE;
+    c->write->handler = peer->send_handler;
+    c->read->handler = peer->recv_handler;
+    /* the kqueue's loop interface needs it. */
+    c->write->handler(c->write);
+}
+#endif
 
 static ngx_int_t
 ngx_http_upstream_check_peek_one_byte(ngx_connection_t *c)
@@ -2534,6 +2621,17 @@ ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
         }
     }
 
+#if (NGX_HTTP_SSL)
+    int is_https_check_type = strcmp((const char *)peer->conf->check_type_conf->name.data, "https") == 0;
+    if (is_https_check_type) {
+      ngx_http_upstream_check_srv_conf_t  *ucscf;
+      ucscf = peer->conf;
+      if (ucscf->ssl.ctx) {
+        ngx_ssl_shutdown(peer->pc.connection);
+        SSL_CTX_free(ucscf->ssl.ctx);
+      }
+    }
+#endif
     peer->shm->access_time = ngx_current_msec;
 }
 

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -1167,7 +1167,7 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
     c->sendfile = 0;
     c->read->log = c->log;
     c->write->log = c->log;
-    c->pool = ngx_create_pool(ngx_pagesize, ngx_cycle->log);
+    c->pool = ngx_create_pool(NGX_CYCLE_POOL_SIZE, ngx_cycle->log);
 #if (NGX_HTTP_SSL)
     if (is_https_check_type && rc == NGX_AGAIN) {
         c->write->handler = ngx_http_upstream_do_ssl_handshake;
@@ -1196,10 +1196,7 @@ static void free_SSL_data(ngx_http_upstream_check_peer_t *peer){
 		ngx_connection_t *c = peer->pc.connection;
     if (is_https_check(peer) &&
 				c->ssl) {
-        ngx_ssl_free_buffer(c);
-        c->ssl->no_wait_shutdown = 1;
-        c->ssl->no_send_shutdown = 1;
-        ngx_ssl_shutdown(c);
+        SSL_free(c->ssl->connection);
         c->ssl = NULL;
         }
 }
@@ -1212,7 +1209,7 @@ static void ngx_http_upstream_do_ssl_handshake(ngx_event_t *event) {
     c = event->data;
     peer = c -> data;
     ucscf = peer->conf;
-    rc = ngx_ssl_create_connection(&ucscf->ssl, c, NGX_SSL_CLIENT );
+    rc = ngx_ssl_create_connection(&ucscf->ssl, c, NGX_SSL_BUFFER|NGX_SSL_CLIENT);
     if (rc != NGX_OK){
       return;
     }

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -1200,7 +1200,12 @@ upstream_check_connect_done:
 #if (NGX_HTTP_SSL)
 
 static void free_SSL_data(ngx_http_upstream_check_peer_t *peer){
+
+    if(!peer) { return; }
+
 	ngx_connection_t *c = peer->pc.connection;
+    if(!c) { return; }
+
     if (is_https_check(peer) && c->ssl) {
         SSL_free(c->ssl->connection);
         c->ssl = NULL;
@@ -3655,6 +3660,8 @@ ngx_http_upstream_check_init_main_conf(ngx_conf_t *cf, void *conf)
     ngx_uint_t                      i;
     ngx_http_upstream_srv_conf_t  **uscfp;
     ngx_http_upstream_main_conf_t  *umcf;
+    ngx_uint_t                      j;
+    ngx_http_upstream_server_t *upset;
 
     umcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_module);
 
@@ -3675,6 +3682,11 @@ ngx_http_upstream_check_init_main_conf(ngx_conf_t *cf, void *conf)
 
         if (ngx_http_upstream_check_init_srv_conf(cf, uscfp[i]) != NGX_OK) {
             return NGX_CONF_ERROR;
+        }
+
+        upset = uscfp[i]->servers->elts;
+        for (j = 0; j < uscfp[i]->servers->nelts; j++) {
+            ngx_http_upstream_check_add_peer(cf,uscfp[i], upset[j].addrs);
         }
     }
 

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -238,7 +238,7 @@ struct ngx_http_upstream_check_srv_conf_s {
 
     ngx_uint_t                               default_down;
 #if (NGX_HTTP_SSL)
-    ngx_ssl_t                       ssl;
+    ngx_ssl_t                                ssl;
 #endif
 };
 


### PR DESCRIPTION
Issue: The nginx module does not supports a health check with https. This Pull Request provides the new type `https`.

e.g:

       upstream  test-upstream{

         server test.server.de:443 weight=1;
         server test.server.de:443 weight=1;

         check interval=3000 type=https rise=4 fall=2 ;
         check_http_send "GET /api/getServerStatus HTTP/1.0\r\n\r\n";

         keepalive 64;
       }


* Cherry picked  commit `79ba411d4014be5c1ce6bbe762366a25109e18ff` from https://github.com/Refinitiv/nginx_upstream_check_module.git and fixes some bugs
* Tested with build properties:  
`--prefix=/DBA/apache/NGX/1.24.0 --with-debug --with-openssl=./openssl-3.0.8  --add-module=./nginx_upstream_check_module`
* fixes #253

