### PR TITLE
Nginx1.28.patch && fix tcp check && support https check && support prometheus

### DIFF
--- a/check_1.28.0+.patch
+++ b/check_1.28.0+.patch
@@ -1,0 +1,240 @@
+diff --git a/src/http/modules/ngx_http_upstream_hash_module.c b/src/http/modules/ngx_http_upstream_hash_module.c
+index 2ecc8d3..f92d097 100644
+--- a/src/http/modules/ngx_http_upstream_hash_module.c
++++ b/src/http/modules/ngx_http_upstream_hash_module.c
+@@ -9,6 +9,9 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++#include "ngx_http_upstream_check_module.h"
++#endif
+ 
+ typedef struct {
+     uint32_t                            hash;
+@@ -250,6 +253,14 @@ ngx_http_upstream_get_hash_peer(ngx_peer_connection_t *pc, void *data)
+             goto next;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                       "get hash peer, check_index: %ui", peer->check_index);
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            goto next;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -628,6 +639,15 @@ ngx_http_upstream_get_chash_peer(ngx_peer_connection_t *pc, void *data)
+                 continue;
+             }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                            "get consistent_hash peer, check_index: %ui",
++                            peer->check_index);
++            if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++                continue;
++            }
++#endif
++
+             if (peer->server.len != server->len
+                 || ngx_strncmp(peer->server.data, server->data, server->len)
+                    != 0)
+diff --git a/src/http/modules/ngx_http_upstream_ip_hash_module.c b/src/http/modules/ngx_http_upstream_ip_hash_module.c
+index 1c1b41d..8cc0b3a 100644
+--- a/src/http/modules/ngx_http_upstream_ip_hash_module.c
++++ b/src/http/modules/ngx_http_upstream_ip_hash_module.c
+@@ -9,6 +9,9 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++#include "ngx_http_upstream_check_module.h"
++#endif
+ 
+ typedef struct {
+     /* the round robin data must be first */
+@@ -216,6 +219,15 @@ ngx_http_upstream_get_ip_hash_peer(ngx_peer_connection_t *pc, void *data)
+             goto next;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++            "get ip_hash peer, check_index: %ui",
++                peer->check_index);
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            goto next;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+diff --git a/src/http/modules/ngx_http_upstream_least_conn_module.c b/src/http/modules/ngx_http_upstream_least_conn_module.c
+index 4df9777..3b33ade 100644
+--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
++++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
+@@ -9,6 +9,9 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++#include "ngx_http_upstream_check_module.h"
++#endif
+ 
+ static ngx_int_t ngx_http_upstream_init_least_conn_peer(ngx_http_request_t *r,
+     ngx_http_upstream_srv_conf_t *us);
+@@ -153,6 +156,16 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+             continue;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                "get least_conn peer, check_index: %ui",
++                peer->check_index);
++
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -160,6 +173,16 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+             continue;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                "get least_conn peer, check_index: %ui",
++                peer->check_index);
++
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_conns && peer->conns >= peer->max_conns) {
+             continue;
+         }
+diff --git a/src/http/ngx_http_upstream_round_robin.c b/src/http/ngx_http_upstream_round_robin.c
+index 4637318..789c0da 100644
+--- a/src/http/ngx_http_upstream_round_robin.c
++++ b/src/http/ngx_http_upstream_round_robin.c
+@@ -9,6 +9,9 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++#include "ngx_http_upstream_check_module.h"
++#endif
+ 
+ #define ngx_http_upstream_tries(p) ((p)->tries                                \
+                                     + ((p)->next ? (p)->next->tries : 0))
+@@ -211,6 +214,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++                if (!server[i].down) {
++                    peer[n].check_index =
++                        ngx_http_upstream_check_add_peer(cf, us, &server[i].addrs[j]);
++                } else {
++                    peer[n].check_index = (ngx_uint_t) NGX_ERROR;
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -337,6 +349,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++                if (!server[i].down) {
++                    peer[n].check_index =
++                        ngx_http_upstream_check_add_peer(cf, us, &server[i].addrs[j]);
++                } else {
++                    peer[n].check_index = (ngx_uint_t) NGX_ERROR;
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -404,6 +425,9 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
+         peer[i].max_conns = 0;
+         peer[i].max_fails = 1;
+         peer[i].fail_timeout = 10;
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        peer[i].check_index = (ngx_uint_t) NGX_ERROR;
++#endif
+         *peerp = &peer[i];
+         peerp = &peer[i].next;
+     }
+@@ -529,6 +553,9 @@ ngx_http_upstream_create_round_robin_peer(ngx_http_request_t *r,
+         peer[0].max_conns = 0;
+         peer[0].max_fails = 1;
+         peer[0].fail_timeout = 10;
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        peer[0].check_index = (ngx_uint_t) NGX_ERROR;
++#endif
+         peers->peer = peer;
+ 
+     } else {
+@@ -563,6 +590,9 @@ ngx_http_upstream_create_round_robin_peer(ngx_http_request_t *r,
+             peer[i].max_conns = 0;
+             peer[i].max_fails = 1;
+             peer[i].fail_timeout = 10;
++#if (NGX_HTTP_UPSTREAM_CHECK)
++            peer[i].check_index = (ngx_uint_t) NGX_ERROR;
++#endif
+             *peerp = &peer[i];
+             peerp = &peer[i].next;
+         }
+@@ -634,6 +664,12 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
+             goto failed;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            goto failed;
++        }
++#endif
++
+         rrp->current = peer;
+         ngx_http_upstream_rr_peer_ref(peers, peer);
+ 
+@@ -733,6 +769,12 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
+             continue;
+         }
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++        if (ngx_http_upstream_check_peer_down(peer->check_index)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+diff --git a/src/http/ngx_http_upstream_round_robin.h b/src/http/ngx_http_upstream_round_robin.h
+index 2f0a51c..1cff6d4 100644
+--- a/src/http/ngx_http_upstream_round_robin.h
++++ b/src/http/ngx_http_upstream_round_robin.h
+@@ -55,6 +55,10 @@ struct ngx_http_upstream_rr_peer_s {
+     ngx_msec_t                      slow_start;
+     ngx_msec_t                      start_time;
+ 
++#if (NGX_HTTP_UPSTREAM_CHECK)
++    ngx_uint_t                      check_index;
++#endif
++
+     ngx_uint_t                      down;
+ 
+ #if (NGX_HTTP_SSL || NGX_COMPAT)

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -7,11 +7,9 @@
 #include <nginx.h>
 #include "ngx_http_upstream_check_module.h"
 
-
 typedef struct ngx_http_upstream_check_peer_s ngx_http_upstream_check_peer_t;
 typedef struct ngx_http_upstream_check_srv_conf_s
     ngx_http_upstream_check_srv_conf_t;
-
 
 #pragma pack(push, 1)
 
@@ -239,6 +237,9 @@ struct ngx_http_upstream_check_srv_conf_s {
     ngx_array_t                             *fastcgi_params;
 
     ngx_uint_t                               default_down;
+#if (NGX_HTTP_SSL)
+    ngx_ssl_t                                ssl;
+#endif
 };
 
 
@@ -339,7 +340,13 @@ static ngx_int_t ngx_http_upstream_check_peek_one_byte(ngx_connection_t *c);
 
 static void ngx_http_upstream_check_begin_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_connect_handler(ngx_event_t *event);
-
+#if (NGX_HTTP_SSL)
+static void ngx_http_upstream_do_ssl_handshake(ngx_event_t *event);
+static void ngx_ups_ssl_handshake(ngx_connection_t *c);
+static int is_https_check(ngx_http_upstream_check_peer_t *peer) {
+    return strcmp((const char *)peer->conf->check_type_conf->name.data, "https") == 0;
+}
+#endif
 static void ngx_http_upstream_check_peek_handler(ngx_event_t *event);
 
 static void ngx_http_upstream_check_send_handler(ngx_event_t *event);
@@ -420,6 +427,8 @@ static void ngx_http_upstream_check_status_html_format(ngx_buf_t *b,
 static void ngx_http_upstream_check_status_csv_format(ngx_buf_t *b,
     ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
 static void ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
+    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
+static void ngx_http_upstream_check_status_prometheus_format(ngx_buf_t *b,
     ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
 
 static ngx_int_t ngx_http_upstream_check_addr_change_port(ngx_pool_t *pool,
@@ -666,7 +675,19 @@ static ngx_check_conf_t  ngx_check_types[] = {
       ngx_http_upstream_check_http_reinit,
       1,
       1 },
-
+#if (NGX_HTTP_SSL)
+    { NGX_HTTP_CHECK_HTTP,
+      ngx_string("https"),
+      ngx_string("GET / HTTP/1.0\r\n\r\n"),
+      NGX_CONF_BITMASK_SET | NGX_CHECK_HTTP_2XX | NGX_CHECK_HTTP_3XX,
+      ngx_http_upstream_check_send_handler,
+      ngx_http_upstream_check_recv_handler,
+      ngx_http_upstream_check_http_init,
+      ngx_http_upstream_check_http_parse,
+      ngx_http_upstream_check_http_reinit,
+      1,
+      1 },
+#endif
     { NGX_HTTP_CHECK_HTTP,
       ngx_string("fastcgi"),
       ngx_null_string,
@@ -742,6 +763,10 @@ static ngx_check_status_conf_t  ngx_check_status_formats[] = {
     { ngx_string("json"),
       ngx_string("application/json"), /* RFC 4627 */
       ngx_http_upstream_check_status_json_format },
+
+    { ngx_string("prometheus"),
+      ngx_string("text/plain"),
+      ngx_http_upstream_check_status_prometheus_format },
 
     { ngx_null_string, ngx_null_string, NULL }
 };
@@ -975,7 +1000,6 @@ ngx_http_upstream_check_add_timers(ngx_cycle_t *cycle)
 
     for (i = 0; i < peers->peers.nelts; i++) {
         peer[i].shm = &peer_shm[i];
-
         peer[i].check_ev.handler = ngx_http_upstream_check_begin_handler;
         peer[i].check_ev.log = cycle->log;
         peer[i].check_ev.data = &peer[i];
@@ -989,6 +1013,11 @@ ngx_http_upstream_check_add_timers(ngx_cycle_t *cycle)
 
         ucscf = peer[i].conf;
         cf = ucscf->check_type_conf;
+#if (NGX_HTTP_SSL)
+		if(is_https_check(&peer[i])) {
+		    ngx_ssl_create(&ucscf->ssl, NGX_SSL_SSLv3 | NGX_SSL_TLSv1 | NGX_SSL_TLSv1_1 | NGX_SSL_TLSv1_2 | NGX_SSL_TLSv1_3 ,0);
+		}
+#endif
 
         if (cf->need_pool) {
             peer[i].pool = ngx_create_pool(ngx_pagesize, cycle->log);
@@ -1093,7 +1122,6 @@ ngx_http_upstream_check_begin_handler(ngx_event_t *event)
     }
 }
 
-
 static void
 ngx_http_upstream_check_connect_handler(ngx_event_t *event)
 {
@@ -1108,6 +1136,12 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
 
     peer = event->data;
     ucscf = peer->conf;
+#if (NGX_HTTP_SSL)
+    int is_https_check_type = is_https_check(peer);
+#else
+    int is_https_check_type = 0;
+#endif
+
 
     if (peer->pc.connection != NULL) {
         c = peer->pc.connection;
@@ -1147,13 +1181,20 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
     c->read->log = c->log;
     c->write->log = c->log;
     c->pool = peer->pool;
+#if (NGX_HTTP_SSL)
+    if (is_https_check_type && rc == NGX_AGAIN) {
+        c->write->handler = ngx_http_upstream_do_ssl_handshake;
+        c->read->handler = ngx_http_upstream_do_ssl_handshake;
+    }
+#endif
 
 upstream_check_connect_done:
     peer->state = NGX_HTTP_CHECK_CONNECT_DONE;
 
-    c->write->handler = peer->send_handler;
-    c->read->handler = peer->recv_handler;
-
+    if (!is_https_check_type) {
+      c->write->handler = peer->send_handler;
+      c->read->handler = peer->recv_handler;
+    }
     ngx_add_timer(&peer->check_timeout_ev, ucscf->check_timeout);
 
     /* The kqueue's loop interface needs it. */
@@ -1161,6 +1202,76 @@ upstream_check_connect_done:
         c->write->handler(c->write);
     }
 }
+
+#if (NGX_HTTP_SSL)
+
+static void free_SSL_data(ngx_http_upstream_check_peer_t *peer){
+
+    if(!peer) { return; }
+
+	ngx_connection_t *c = peer->pc.connection;
+    if(!c) { return; }
+
+    if (is_https_check(peer) && c->ssl) {
+        SSL_free(c->ssl->connection);
+        c->ssl = NULL;
+    }
+}
+
+static void ngx_http_upstream_do_ssl_handshake(ngx_event_t *event) {
+    long                  rc;
+    ngx_connection_t                    *c;
+    ngx_http_upstream_check_peer_t      *peer;
+    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    c = event->data;
+    peer = c -> data;
+    ucscf = peer->conf;
+    rc = ngx_ssl_create_connection(&ucscf->ssl, c, NGX_SSL_BUFFER|NGX_SSL_CLIENT);
+    if (rc != NGX_OK){
+      return;
+    }
+    int tcp_nodelay = 1;
+    if (setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &tcp_nodelay, sizeof(int)) == -1) {
+        ngx_connection_error(c, ngx_socket_errno, "setsockopt(TCP_NODELAY) failed");
+        return;
+    }
+    c->tcp_nodelay = NGX_TCP_NODELAY_SET;
+    rc = ngx_ssl_handshake(c);
+    if (rc != NGX_OK && rc != NGX_AGAIN) {
+        free_SSL_data(peer);
+        return;
+    }
+    if (rc == NGX_AGAIN) {
+        if (!c->write->timer_set) {
+            ngx_add_timer(c->write, ucscf->check_timeout);
+        }
+      c->ssl->handler = ngx_ups_ssl_handshake;
+    }
+    else {
+      ngx_ups_ssl_handshake(c);
+    }
+}
+
+static void
+ngx_ups_ssl_handshake(ngx_connection_t *c) {
+    long                  rc;
+    rc = 0;
+    ngx_http_upstream_check_peer_t      *peer;
+    peer = c->data;
+    if (c->ssl && c->ssl->handshaked) {
+        rc = SSL_get_verify_result(c->ssl->connection);
+    }
+    if (rc != 0) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "SSL_get_verify_result rc: %d", rc);
+    }
+    peer->state = NGX_HTTP_CHECK_CONNECT_DONE;
+    c->write->handler = peer->send_handler;
+    c->read->handler = peer->recv_handler;
+    /* the kqueue's loop interface needs it. */
+    c->write->handler(c->write);
+}
+#endif
 
 static ngx_int_t
 ngx_http_upstream_check_peek_one_byte(ngx_connection_t *c)
@@ -1198,7 +1309,8 @@ ngx_http_upstream_check_peek_handler(ngx_event_t *event)
 
     if (ngx_http_upstream_check_peek_one_byte(c) == NGX_OK) {
         ngx_http_upstream_check_status_update(peer, 1);
-
+        // the TCP channel counts as one request if the connection is normal.
+        c->requests++;
     } else {
         c->error = 1;
         ngx_http_upstream_check_status_update(peer, 0);
@@ -2515,7 +2627,11 @@ ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
     ucscf = peer->conf;
 
     if (result) {
-        peer->shm->rise_count++;
+        if(peer->shm->rise_count < (ngx_uint_t)-1) {
+            peer->shm->rise_count++;
+        }else{
+            peer->shm->rise_count = ucscf->rise_count;
+        }
         peer->shm->fall_count = 0;
         if (peer->shm->down && peer->shm->rise_count >= ucscf->rise_count) {
             peer->shm->down = 0;
@@ -2525,7 +2641,11 @@ ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
         }
     } else {
         peer->shm->rise_count = 0;
-        peer->shm->fall_count++;
+        if(peer->shm->fall_count < (ngx_uint_t)-1) {
+            peer->shm->fall_count++;
+        }else{
+            peer->shm->fall_count = ucscf->fall_count;
+        }
         if (!peer->shm->down && peer->shm->fall_count >= ucscf->fall_count) {
             peer->shm->down = 1;
             ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
@@ -2533,7 +2653,9 @@ ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
                           &peer->check_peer_addr->name);
         }
     }
-
+#if (NGX_HTTP_SSL)
+    free_SSL_data(peer);
+#endif
     peer->shm->access_time = ngx_current_msec;
 }
 
@@ -3040,6 +3162,113 @@ ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
 
     b->last = ngx_snprintf(b->last, b->end - b->last,
             "}}\n");
+}
+
+
+static void
+ngx_http_upstream_check_status_prometheus_format(ngx_buf_t *b,
+    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
+{
+    ngx_uint_t                       count, i;
+    ngx_http_upstream_check_peer_t  *peer;
+
+    peer = peers->peers.elts;
+
+    count = 0;
+
+    for (i = 0; i < peers->peers.nelts; i++) {
+
+        if (flag & NGX_CHECK_STATUS_DOWN) {
+
+            if (!peer[i].shm->down) {
+                continue;
+            }
+
+        } else if (flag & NGX_CHECK_STATUS_UP) {
+
+            if (peer[i].shm->down) {
+                continue;
+            }
+        }
+
+        count++;
+    }
+
+    b->last = ngx_snprintf(b->last, b->end - b->last,
+            "# TYPE nginx_http_upstream_check_total gauge\n"
+            "nginx_http_upstream_check_total %ui\n"
+            "# TYPE nginx_http_upstream_check_total counter\n"
+            "nginx_http_upstream_check_generation %ui\n",
+            count,
+            ngx_http_upstream_check_shm_generation);
+    b->last = ngx_snprintf(b->last, b->end - b->last,
+            "# TYPE nginx_http_upstream_check_peer_status gauge\n"
+            "# TYPE nginx_http_upstream_check_peer_probes counter\n"
+    );
+
+    for (i = 0; i < peers->peers.nelts; i++) {
+
+        if (flag & NGX_CHECK_STATUS_DOWN) {
+
+            if (!peer[i].shm->down) {
+                continue;
+            }
+
+        } else if (flag & NGX_CHECK_STATUS_UP) {
+
+            if (peer[i].shm->down) {
+                continue;
+            }
+        }
+
+        b->last = ngx_snprintf(b->last, b->end - b->last,
+                "nginx_http_upstream_check_peer_status{"
+                "index=\"%ui\","
+                "upstream=\"%V\","
+                "name=\"%v\","
+                "type=\"%V\","
+                "port=\"%ui\"} "
+                "%ui\n",
+                i,
+                peer[i].upstream_name,
+                &peer[i].peer_addr->name,
+                &peer[i].conf->check_type_conf->name,
+                peer[i].conf->port,
+                peer[i].shm->down ? 0 : 1
+                );
+        b->last = ngx_snprintf(b->last, b->end - b->last,
+                "nginx_http_upstream_check_peer_probes{"
+                "index=\"%ui\","
+                "upstream=\"%V\","
+                "name=\"%v\","
+                "type=\"%V\","
+                "port=\"%ui\","
+                "count=\"rise\"} "
+                "%ui\n",
+                i,
+                peer[i].upstream_name,
+                &peer[i].peer_addr->name,
+                &peer[i].conf->check_type_conf->name,
+                peer[i].conf->port,
+                peer[i].shm->rise_count
+                );
+        b->last = ngx_snprintf(b->last, b->end - b->last,
+                "nginx_http_upstream_check_peer_probes{"
+                "index=\"%ui\","
+                "upstream=\"%V\","
+                "name=\"%v\","
+                "type=\"%V\","
+                "port=\"%ui\","
+                "count=\"fall\"} "
+                "%ui\n",
+                i,
+                peer[i].upstream_name,
+                &peer[i].peer_addr->name,
+                &peer[i].conf->check_type_conf->name,
+                peer[i].conf->port,
+                peer[i].shm->fall_count
+                );
+    }
 }
 
 


### PR DESCRIPTION
- 增加1.28.0补丁
- 修复TCP检查: 合并来自[mofantor](https://github.com/mofantor)的 [Nginx1.26.patch and fix raise count does not increase under the TCP check #282](https://github.com/yaoweibin/nginx_upstream_check_module/pull/209)
- 增加HTTPS检查: 合并来自[noeldamps](https://github.com/noeldamps)的[Add https support to check_http_send #281](https://github.com/yaoweibin/nginx_upstream_check_module/pull/281)
- 增加Prometheus信息: 合并来自[triluch](https://github.com/triluch)的[Add prometheus support for status endpoint #209](https://github.com/yaoweibin/nginx_upstream_check_module/pull/282)